### PR TITLE
feat: ability to disable the S3 logging prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Please contribute or open us a ticket for more integrations.
 
 Note: We will ship the logs immediately when the container is shutting down. Therefore, log files can be smaller and more frequent than the above configuration.
 
+(Optional) Disable S3 logging prefix:
+* `LUMIGO_EXTENSION_DISABLE_LOG_PREFIX` (default `False`) indicates the target file should not include the timestampe and record type.
+
 ## How it works
 
 We use the [new extensions feature](https://lumigo.io/blog/aws-lambda-extensions-what-are-they-and-why-do-they-matter/) to trigger a new process that handles your logs.

--- a/src/lambda_telemetry_shipper/configuration.py
+++ b/src/lambda_telemetry_shipper/configuration.py
@@ -10,7 +10,7 @@ def parse_env(env_name: str, default: Optional[str] = None) -> Optional[str]:
 
 def parse_env_to_bool(env_name: str, default: bool) -> bool:
     try:
-        if parse_env(env_name) == 'True':
+        if parse_env(env_name, default="").lower() == "true":
             return True
         return default
     except Exception:

--- a/src/lambda_telemetry_shipper/configuration.py
+++ b/src/lambda_telemetry_shipper/configuration.py
@@ -8,6 +8,18 @@ def parse_env(env_name: str, default: Optional[str] = None) -> Optional[str]:
     return os.environ.get(env_name, default)
 
 
+def parse_env_to_bool(env_name: str, default: bool) -> bool:
+    try:
+        if parse_env(env_name) == 'True':
+            return True
+        return default
+    except Exception:
+        get_logger().exception(
+            f"Unable to parse environment {env_name}. Fallback to default."
+        )
+        return default
+
+
 def parse_env_to_int(env_name: str, default: int) -> int:
     try:
         return int(parse_env(env_name) or default)
@@ -19,6 +31,9 @@ def parse_env_to_int(env_name: str, default: int) -> int:
 
 
 class Configuration:
+    # Should we log only the data (true) or include the time & record type as a prefix (false; default behaviour)
+    disable_log_prefix: Optional[bool] = parse_env_to_bool("LUMIGO_EXTENSION_DISABLE_LOG_PREFIX", False)
+
     # Min batch size. Default 1KB (don't send before reaching this amount)
     min_batch_size: int = parse_env_to_int("LUMIGO_EXTENSION_LOG_BATCH_SIZE", 1_000)
 

--- a/src/lambda_telemetry_shipper/export_logs_handlers/s3_handler.py
+++ b/src/lambda_telemetry_shipper/export_logs_handlers/s3_handler.py
@@ -36,6 +36,6 @@ class S3Handler(ExportLogsHandler):
     @staticmethod
     def _format_record(r: TelemetryRecord):
         if Configuration.disable_log_prefix:
-            return f"{r.record}"
+            return r.record
 
         return f"{r.record_time.isoformat():{TIME_PADDING}}{r.record_type.value:{TYPE_PADDING}}{r.record}"

--- a/src/lambda_telemetry_shipper/export_logs_handlers/s3_handler.py
+++ b/src/lambda_telemetry_shipper/export_logs_handlers/s3_handler.py
@@ -35,4 +35,7 @@ class S3Handler(ExportLogsHandler):
 
     @staticmethod
     def _format_record(r: TelemetryRecord):
+        if Configuration.disable_log_prefix:
+            return f"{r.record}"
+
         return f"{r.record_time.isoformat():{TIME_PADDING}}{r.record_type.value:{TYPE_PADDING}}{r.record}"

--- a/src/test/lambda_log_shipper/export_logs_handlers/test_s3_handler.py
+++ b/src/test/lambda_log_shipper/export_logs_handlers/test_s3_handler.py
@@ -40,7 +40,7 @@ def test_format_records(record):
 
 
 def test_format_records_with_prefix_disabled(record, monkeypatch):
-    monkeypatch.setattr(Configuration, "disable_log_prefix", "true")
+    monkeypatch.setattr(Configuration, "disable_log_prefix", True)
 
     t1 = datetime.datetime(2020, 5, 22, 10, 20, 30, 123456)
     r1 = TelemetryRecord(record_type=LogType.START, record_time=t1, record="a", raw={})

--- a/src/test/lambda_log_shipper/export_logs_handlers/test_s3_handler.py
+++ b/src/test/lambda_log_shipper/export_logs_handlers/test_s3_handler.py
@@ -39,6 +39,21 @@ def test_format_records(record):
     assert data.decode() == expected
 
 
+def test_format_records_with_prefix_disabled(record, monkeypatch):
+    monkeypatch.setattr(Configuration, "disable_log_prefix", "true")
+
+    t1 = datetime.datetime(2020, 5, 22, 10, 20, 30, 123456)
+    r1 = TelemetryRecord(record_type=LogType.START, record_time=t1, record="a", raw={})
+    r2 = TelemetryRecord(
+        record_type=LogType.FUNCTION, record_time=t1, record="b", raw={}
+    )
+
+    data = S3Handler.format_records([r1, r2])
+
+    expected = "a\nb"
+    assert data.decode() == expected
+
+
 @mock_s3
 def test_handle_logs_happy_flow(record, monkeypatch):
     s3 = boto3.client("s3", region_name="us-west-2")

--- a/src/test/lambda_log_shipper/test_configuration.py
+++ b/src/test/lambda_log_shipper/test_configuration.py
@@ -36,7 +36,7 @@ def test_parse_env_to_int_not_exists(monkeypatch):
         ("False", False),
         ("True", True),
         ("false", False),
-        ("true", False),
+        ("true", True),
         ("bad_value", False),
     ],
 )

--- a/src/test/lambda_log_shipper/test_configuration.py
+++ b/src/test/lambda_log_shipper/test_configuration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lambda_telemetry_shipper.configuration import parse_env, parse_env_to_int
+from lambda_telemetry_shipper.configuration import parse_env, parse_env_to_bool, parse_env_to_int
 
 
 def test_parse_env_exists(monkeypatch):
@@ -28,3 +28,23 @@ def test_parse_env_to_int_exists(actual_env, expected_result, monkeypatch):
 def test_parse_env_to_int_not_exists(monkeypatch):
     monkeypatch.delenv("ENV_VAR", None)
     assert parse_env_to_int("ENV_VAR", 5) == 5
+
+
+@pytest.mark.parametrize(
+    "actual_env, expected_result",
+    [
+        ("False", False),
+        ("True", True),
+        ("false", False),
+        ("true", False),
+        ("bad_value", False),
+    ],
+)
+def test_parse_env_to_bool_exists(actual_env, expected_result, monkeypatch):
+    monkeypatch.setenv("ENV_VAR", actual_env)
+    assert parse_env_to_bool("ENV_VAR", False) == expected_result
+
+
+def test_parse_env_to_bool_not_exists(monkeypatch):
+    monkeypatch.delenv("ENV_VAR", None)
+    assert parse_env_to_bool("ENV_VAR", False) == False


### PR DESCRIPTION
A lambda may be outputting JSON to be ingested by another service, such as QuickSight. This extension currently prefixes the lambdas output with a timestampe and the record type.

This change allows the prefix to be disbaled by setting `LUMIGO_EXTENSION_DISABLE_LOG_PREFIX` to `True`.